### PR TITLE
Set installed locale to UTF-8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ pillar: ./pillar/build.sls
 	echo "build_hash: ${GIT_SHORT}" >> ./pillar/build.sls
 
 artifacts:
-	@mkdir "${ARTIFACTS_PATH}"
+	install -d "${ARTIFACTS_PATH}"
+	echo "${DATE_STAMP}" >  ${ARTIFACTS_PATH}/date
+	echo "${GIT_SHORT}" >  ${ARTIFACTS_PATH}/git_short
 	echo "${DATE_STAMP}-${GIT_SHORT}" > ${ARTIFACTS_PATH}/latest
 
 build: pillar artifacts

--- a/http/ubuntu/preseed.cfg
+++ b/http/ubuntu/preseed.cfg
@@ -1,4 +1,4 @@
-d-i debian-installer/locale string en_US
+d-i debian-installer/locale string en_US.UTF-8
 d-i time/zone string UTC
 
 d-i keyboard-configuration/xkb-keymap select us


### PR DESCRIPTION
Tested on a new rails project which normally complained about UTF-8 encodings, works like a charm!

```
vagrant [cats]> rails db:create
Created database 'development'
Created database 'test'
```

close #13 